### PR TITLE
Custom args

### DIFF
--- a/html-to-pdf/html-to-pdf.js
+++ b/html-to-pdf/html-to-pdf.js
@@ -3,8 +3,8 @@ const puppeteer = require('puppeteer')
 const printPDF = async (html, options) => {
 
 //  const pathToHtml = path.join(__dirname, filename);
-
-  const browser = await puppeteer.launch({ headless: true });
+  puppeteer_args = process.env.puppeteer_args;
+  const browser = await puppeteer.launch({ headless: true , args: puppeteer_args});
   const page = await browser.newPage();
   await page.setContent(html, { waitUntil: 'networkidle0' });
 

--- a/html-to-pdf/html-to-pdf.js
+++ b/html-to-pdf/html-to-pdf.js
@@ -3,7 +3,7 @@ const puppeteer = require('puppeteer')
 const printPDF = async (html, options) => {
 
 //  const pathToHtml = path.join(__dirname, filename);
-  puppeteer_args = process.env.puppeteer_args;
+  puppeteer_args = process.env.puppeteer_args.split(',');
   const browser = await puppeteer.launch({ headless: true , args: puppeteer_args});
   const page = await browser.newPage();
   await page.setContent(html, { waitUntil: 'networkidle0' });


### PR DESCRIPTION
When running puppeteer (and node red with this node) in docker, it is useful to be able pass custom arguments to puppeteer  in order to disable the sandbox requirements. 

This change allows you to specify those arguments with a `puppeteer_args` global variable.

This setting will disable the sandbox requirement:
`puppeteer_args = "--no-sandbox, --disable setuid-sandbox"`
